### PR TITLE
Do not match on complete error message of checkmate in tests

### DIFF
--- a/tests/testthat/test-nsim.R
+++ b/tests/testthat/test-nsim.R
@@ -14,41 +14,41 @@ test_that("nsim returns a single, double value", {
 test_that("alpha is in the appropriate range", {
   expect_error(
     nsim(alpha = 1.5, sigma = 1, delta = 1, power = 0.5),
-    "Variable 'alpha': All elements must be <= 1",
-    fixed = TRUE
+    "Variable 'alpha': .+ <= 1",
+    fixed = FALSE
   )
   expect_error(
     nsim(alpha = -0.1, sigma = 1, delta = 1, power = 0.5),
-    "Variable 'alpha': All elements must be >= 0",
-    fixed = TRUE
+    "Variable 'alpha': .+ >= 0",
+    fixed = FALSE
   )
 })
 
 test_that("sigma is greater than zero", {
   expect_error(
     nsim(alpha = 0.05, sigma = -0.1, delta = 1, power = -0.1),
-    "Variable 'sigma': All elements must be >= 0",
-    fixed = TRUE
+    "Variable 'sigma': .+ >= 0",
+    fixed = FALSE
   )
 })
 
 test_that("delta is greater than zero", {
   expect_error(
     nsim(alpha = 0.05, sigma = 1, delta = -0.1, power = -0.1),
-    "Variable 'delta': All elements must be >= 0",
-    fixed = TRUE
+    "Variable 'delta': .+ >= 0",
+    fixed = FALSE
   )
 })
 
 test_that("power is in the appropriate range", {
   expect_error(
     nsim(alpha = 0.05, sigma = 1, delta = 1, power = 1.5),
-    "Variable 'power': All elements must be <= 1",
-    fixed = TRUE
+    "Variable 'power': .+ <= 1",
+    fixed = FALSE
   )
   expect_error(
     nsim(alpha = 0.05, sigma = 1, delta = 1, power = -0.1),
-    "Variable 'power': All elements must be >= 0",
-    fixed = TRUE
+    "Variable 'power': .+ >= 0",
+    fixed = FALSE
   )
 })


### PR DESCRIPTION
Hi there,

While preparing a new release of checkmate, I improved some error messages to provide additional information, e.g. the location of the first missing value in a vector. This unfortunately broke a unit test in your package. This PR should fix the test in question. Instead of matching on the complete sentence, the new pattern just matches the relevant part.
I currently see no better way around this to make this more future-proof ...

It would be great if you could release a new version to CRAN in the next few weeks.

Best,
Michel