### PR TITLE
Update control$df to control$power_df in simsum.R

### DIFF
--- a/R/simsum.R
+++ b/R/simsum.R
@@ -126,7 +126,7 @@ simsum <- function(data,
   checkmate::assert_subset(x = names(control), choices = c("mcse", "level", "power_df", "na.rm", "char.sep", "dropbig.max", "dropbig.semax", "dropbig.robust"), empty.ok = TRUE, add = arg_checks)
   checkmate::assert_logical(x = control$mcse, len = 1, null.ok = TRUE, add = arg_checks)
   checkmate::assert_number(x = control$level, lower = 0, upper = 1, null.ok = TRUE, add = arg_checks)
-  checkmate::assert_number(x = control$df, null.ok = TRUE, add = arg_checks)
+  checkmate::assert_number(x = control$power_df, null.ok = TRUE, add = arg_checks)
   checkmate::assert_logical(x = control$na.rm, len = 1, null.ok = TRUE, add = arg_checks)
   checkmate::assert_string(x = control$char.sep, null.ok = TRUE, add = arg_checks)
   checkmate::assert_number(x = control$dropbig.max, null.ok = TRUE, add = arg_checks)
@@ -139,7 +139,7 @@ simsum <- function(data,
   if (!is.null(ci.limits) & !is.null(df)) stop("Only one of 'ci.limits' and 'df' can be specified.", call. = FALSE)
 
   ### Set control parameters
-  control.default <- list(mcse = TRUE, level = 0.95, df = NULL, na.rm = TRUE, char.sep = "~", dropbig.max = 10, dropbig.semax = 100, dropbig.robust = TRUE)
+  control.default <- list(mcse = TRUE, level = 0.95, power_df = NULL, na.rm = TRUE, char.sep = "~", dropbig.max = 10, dropbig.semax = 100, dropbig.robust = TRUE)
   control.tmp <- unlist(list(
     control[names(control) %in% names(control.default)],
     control.default[!(names(control.default) %in% names(control))]


### PR DESCRIPTION
Thank you for your great package. 
When applying it and comparing it to the results of my own code, I got different power/rejection-rates and checked your code. Your check of the control list seems to have a small error due to changes in names. Your checking if control$df is a number instead of control$power_df. This means that you cannot specify power_df at the moment. It's either set to the default NULL when you specify power_df in the control list or if you specify df it's returning an error for the name-control of the list.